### PR TITLE
Specifies the file type for the find command

### DIFF
--- a/SCRIPTS/03_convert_translation.sh
+++ b/SCRIPTS/03_convert_translation.sh
@@ -5,7 +5,7 @@
 # Convert translation files zh-cn to zh_Hans
 # The script is still in testing, welcome to report bugs.
 
-po_file="$({ find |grep -E "[a-z0-9]+\.zh\-cn.+po"; } 2>"/dev/null")"
+po_file="$({ find -type f |grep -E "[a-z0-9]+\.zh\-cn.+po"; } 2>"/dev/null")"
 for a in ${po_file}
 do
 	[ -n "$(grep "Language: zh_CN" "$a")" ] && sed -i "s/Language: zh_CN/Language: zh_Hans/g" "$a"
@@ -13,7 +13,7 @@ do
 	mv "$a" "${po_new_file}" 2>"/dev/null"
 done
 
-po_file2="$({ find |grep "/zh-cn/" |grep "\.po"; } 2>"/dev/null")"
+po_file2="$({ find -type f |grep "/zh-cn/" |grep "\.po"; } 2>"/dev/null")"
 for b in ${po_file2}
 do
 	[ -n "$(grep "Language: zh_CN" "$b")" ] && sed -i "s/Language: zh_CN/Language: zh_Hans/g" "$b"
@@ -21,28 +21,28 @@ do
 	mv "$b" "${po_new_file2}" 2>"/dev/null"
 done
 
-lmo_file="$({ find |grep -E "[a-z0-9]+\.zh_Hans.+lmo"; } 2>"/dev/null")"
+lmo_file="$({ find -type f |grep -E "[a-z0-9]+\.zh_Hans.+lmo"; } 2>"/dev/null")"
 for c in ${lmo_file}
 do
 	lmo_new_file="$(echo -e "$c"|sed "s/zh_Hans/zh-cn/g")"
 	mv "$c" "${lmo_new_file}" 2>"/dev/null"
 done
 
-lmo_file2="$({ find |grep "/zh_Hans/" |grep "\.lmo"; } 2>"/dev/null")"
+lmo_file2="$({ find -type f |grep "/zh_Hans/" |grep "\.lmo"; } 2>"/dev/null")"
 for d in ${lmo_file2}
 do
 	lmo_new_file2="$(echo -e "$d"|sed "s/zh_Hans/zh-cn/g")"
 	mv "$d" "${lmo_new_file2}" 2>"/dev/null"
 done
 
-po_dir="$({ find |grep "/zh-cn" |sed "/\.po/d" |sed "/\.lmo/d"; } 2>"/dev/null")"
+po_dir="$({ find -type d |grep "/zh-cn" |sed "/\.po/d" |sed "/\.lmo/d"; } 2>"/dev/null")"
 for e in ${po_dir}
 do
 	po_new_dir="$(echo -e "$e"|sed "s/zh-cn/zh_Hans/g")"
 	mv "$e" "${po_new_dir}" 2>"/dev/null"
 done
 
-makefile_file="$({ find|grep Makefile |sed "/Makefile./d"; } 2>"/dev/null")"
+makefile_file="$({ find -type f |grep Makefile |sed "/Makefile./d"; } 2>"/dev/null")"
 for f in ${makefile_file}
 do
 	[ -n "$(grep "zh-cn" "$f")" ] && sed -i "s/zh-cn/zh_Hans/g" "$f"


### PR DESCRIPTION
03_convert_translation.sh 脚本存在误伤，如下图错误更改 Yacd-meta 的文件名，对 03 脚本中的 find 命令指明文件或目录，进行修复
<img width="751" alt="屏幕截图 2023-06-18 011232" src="https://github.com/nicholas-opensource/OpenWrt-Autobuild/assets/68163551/2a859a77-d12f-43f0-b9c0-8321790d124f">
